### PR TITLE
Firebase version removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,3 +55,7 @@
 * Controllers are changed to Instances.
 * Permissions based feature control
 * [Bug fixes]
+
+## 1.2.1
+* Firebase dependencies updated
+* Documentation Bug fixes

--- a/README.md
+++ b/README.md
@@ -17,11 +17,6 @@ Ofcourse, a chat screen to chat. No explaination needed but, Yes you can change 
 7. Push Notifications
 8. All Chatting Features
 
-## Getting started
-
-Okay so its not that complicated.
-First you have to execute this line of code at the begining of the project where you get the user detials..
-> You can place it on the Login page / Controller.
 
 
 ## Gallery
@@ -115,9 +110,8 @@ For example
 More is about to Come:
 
 **Features that will be added later:**
-1. Voice Notes
-2. Push Notifications
-3. Make it for web
+1. Push Notifications
+2. Make it for web
 
 
 ## Frameworks Used

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -36,10 +36,12 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
-  cloud_firestore: ^3.1.15
-  firebase_core: ^1.17.0
-  firebase_storage: ^10.2.16
-  firebase_auth: ^3.3.18
+
+  # Firebase Details
+  firebase_core: ^2.1.1
+  cloud_firestore: ^4.2.0
+  firebase_auth: ^4.2.0
+  firebase_storage: ^11.0.7
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,9 +16,9 @@ dependencies:
   image_picker: ^0.8.5
 
   # Firebase Dependencies
-  firebase_core: ^2.1.1
-  cloud_firestore: ^4.2.0
-  firebase_storage: ^11.0.7
+  firebase_core:
+  cloud_firestore:
+  firebase_storage:
 
   audio_waveforms: ^0.1.5
   cached_network_image: ^3.2.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: apptex_chat
 description: This Package is for making the chat system more easy and user friendly. and control chat features within one click.
-version: 1.2.0
+version: 1.2.1
 homepage: https://github.com/apptexsolutions/apptex_chat
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,9 +14,12 @@ dependencies:
   #Dependencies
   get: ^4.6.1
   image_picker: ^0.8.5
-  cloud_firestore: ^3.1.15
-  firebase_core: ^1.17.0
-  firebase_storage: ^10.2.16
+
+  # Firebase Dependencies
+  firebase_core: ^2.1.1
+  cloud_firestore: ^4.2.0
+  firebase_storage: ^11.0.7
+
   audio_waveforms: ^0.1.5
   cached_network_image: ^3.2.2
   permission_handler: ^10.2.0


### PR DESCRIPTION
When the project has firebase versions defined, then when you import it to any project you must will have to use the exact firebase vversion.. 
So now by removing those versions, you can set up any of the firebase versions  you want to add. 